### PR TITLE
🔧 fix(type): resolve ty 0.0.25 type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
   "pytest-cov>=7",
 ]
 type = [
-  "ty>=0.0.19,<0.0.25",
+  "ty>=0.0.19",
   { include-group = "test" },
 ]
 lint = [

--- a/tests/test_devpi_process.py
+++ b/tests/test_devpi_process.py
@@ -70,4 +70,6 @@ def test_create_server_with_pypi(tmp_path: Path) -> None:
 def test_create_server_start_args(tmp_path: Path) -> None:
     with IndexServer(tmp_path, start_args=["--offline-mode"]) as server:
         assert server._process is not None  # noqa: SLF001
-        assert server._process.args[-1] == "--offline-mode"  # type: ignore[index] # noqa: SLF001
+        args = server._process.args  # noqa: SLF001
+        assert isinstance(args, list)
+        assert args[-1] == "--offline-mode"


### PR DESCRIPTION
ty 0.0.25 introduced stricter type checking. This fixes the `not-subscriptable` error on `Popen.args` by narrowing the type with `isinstance`, and removes the temporary version pin.